### PR TITLE
Support for Fests

### DIFF
--- a/src/components/Shows.vue
+++ b/src/components/Shows.vue
@@ -30,7 +30,10 @@
 
 			<p v-for="show in reverseChronShows" v-if="show.archive !== false">
 				<strong>{{ show.date | formatDate }}</strong> &#151; 
-				<span v-if="show.bands" v-for="(band, index) in show.bands">{{ band.name }}<span v-if="index+1 < show.bands.length">, </span></span> <!-- comma-separated list of bands -->
+				<span v-if="show.note">{{ show.note }}</span>
+				<span v-else>
+					<span v-if="show.bands" v-for="(band, index) in show.bands">{{ band.name }}<span v-if="index+1 < show.bands.length">, </span></span> <!-- comma-separated list of bands -->
+				</span>
 				@ {{ show.location }}
 			</p>
 		</section>

--- a/src/components/Shows.vue
+++ b/src/components/Shows.vue
@@ -7,7 +7,14 @@
 			<h2>Upcoming Shows</h2>
 			<ul>
 				<li v-for="show in chronShows" v-if="show.archive === false">
-					<strong>{{ show.date | formatDate }}</strong>
+					<strong>
+						<span v-if="show.dateEnd">
+							{{ show.date | formatDateShort }} &#45; {{ show.dateEnd | formatDate }}
+						</span>
+						<span v-else>
+							{{ show.date | formatDate }}
+						</span>
+					</strong>
 					<span v-if="show.note" class="note">{{ show.note }}</span>
 					<span class="location">{{ show.location }}</span>
 					<span v-if="show.bands" v-for="(band, index) in show.bands" class="band">
@@ -65,7 +72,10 @@
 		filters: {
 			formatDate: function(value) {
 				if (value) return moment(String(value)).format('MMMM D YYYY')
-		  	}
+			},
+			formatDateShort: function(value) {
+				if (value) return moment(String(value)).format('MMMM D')
+			}
 		}
 	}
 


### PR DESCRIPTION
* added an additional field to shows (`dateEnd`) in addition to `date` to accommodate shows that last multiple days
* archive: if a show has a `note` (commonly used for fest names), display that instead of the band list

![screen shot 2018-07-04 at 11 08 31 pm](https://user-images.githubusercontent.com/5122304/42300651-7b4b6666-7fdf-11e8-9106-053d71eb2c8e.png)

**TO DO**
- dates can get wordy – would be preferred to drop the month name when possible (e.g. "September 21-23 2018"
- date formatting filters could be DRYer – consider passing an additional argument, rather than creating multiple functions
- display `dateEnd` in the archive as well as in the Upcoming Shows