### PR TITLE
Safer usage of env variables.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "dotenv": "^7.0.0",
+    "dotenv-webpack": "^1.7.0",
     "firebase": "^5.8.6",
     "moment": "^2.18.1",
     "vue": "^2.3.3",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -5,7 +5,6 @@ const firebaseApp = Firebase.initializeApp({
 	authDomain: process.env.AUTH_DOMAIN,
 	databaseURL: process.env.DATABASE_URL,
 	storageBucket: process.env.STORAGE_BUCKET,
-	projectId: process.env.PROJECT_ID,
 	messagingSenderId: process.env.MESSAGING_SENDER_ID
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,6 @@
 var path = require('path')
 var webpack = require('webpack')
-var dotenv = require('dotenv')
-
-// use dotenv to load either .env (dev mode) or .env.production 
-// (production mode) into process.env and convert all values to strings 
-// such that they can be used in webpack.DefinePlugin properly
-// https://webpack.js.org/plugins/define-plugin/#usage
-dotenv.config({ path: process.env.NODE_ENV === 'production' ? '.env.production' : '.env' })
-env = {}
-Object.entries(process.env).forEach(([key, val]) => env[key] = JSON.stringify(val))
+var Dotenv = require('dotenv-webpack')
 
 module.exports = {
   entry: './src/main.js',
@@ -61,12 +53,12 @@ module.exports = {
   },
   devtool: '#eval-source-map',
   plugins: [
-    // provide values to application from process.env
-    new webpack.DefinePlugin({
-      'process.env': Object.assign({ 
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV)
-      }, env)
-    }),
+    // provide values to application from process.env, only providing
+    // values referenced in codebase, which is safer than providing all env
+    // values
+    new Dotenv({
+      path: process.env.NODE_ENV === 'production' ? '.env.production' : '.env'
+    })
   ]
 }
 


### PR DESCRIPTION
- using the `dotenv` package alone was appending all environmental variables
  from the build machine to the build, including values from other
  potentially sensitive processes on the host machine. This is not good!
- using `dotenv-webpack`, only env values that are actually referenced in the
  app are bundled in the build.
- yes indeed, the env values that are used in the app are bundled into
  the build. There is no easy way to avoid this with a client-side
  rendered app. However, the values at least are not easily available on GitHub,
  a place where it looks unprofessional to have those values saved in a file,
  and a place  which is full of people who actually know how to take advantage
  of those secret values!